### PR TITLE
Added another way to pronounce openhab

### DIFF
--- a/vocab/en-us/RefreshTaggedItemsKeyword.voc
+++ b/vocab/en-us/RefreshTaggedItemsKeyword.voc
@@ -1,1 +1,2 @@
 refresh open hab items
+refresh openhab items


### PR DESCRIPTION
I could never get mycroft respond as it would recognize my phrase as `refresh openhab items` instead of `refresh open hab items`.

This PR allows for both ways to be handled