### PR TITLE
[DOC] Update README.md installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ From 18.2.5b mycroft-core release it is possible to install the skill using the 
 
 or via the [msm](https://mycroft.ai/documentation/msm/) command:
 ```shell
-msm install openhab
+msm install https://github.com/openhab/openhab-mycroft
 ```
 
 To manually install the skill:


### PR DESCRIPTION
`msm install openhab` did not work for me:
```
    INFO - Best match (0.26): emby by rickyphewitt
    SkillNotFound: openhab
```

What I had to use instead is `msm install https://github.com/openhab/openhab-mycroft`.

Please let me know if `msm install openhab` should work infact and it's just a problem of my setup.