### PR TITLE
Change to using skill settings instead of old config

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,19 +64,6 @@ cd skill-openhab
 pip install -r requirements.txt
 ```
 
-### Configuration
-
-Add the block below to your `mycroft.conf` file:
-
-```json
- "openHABSkill": {
-        "host": "openHAB server ip",
-        "port": "openHAB server port"
-      }
-```
-
-Restart mycroft for the changes to take effect.
-
 ## Examples 
 * " Hey Mycroft, turn on Diningroom Light"
 * "Hey Mycroft, switch off Kitchen Light"

--- a/__init__.py
+++ b/__init__.py
@@ -48,7 +48,7 @@ class openHABSkill(MycroftSkill):
 	def __init__(self):
 		super(openHABSkill, self).__init__(name="openHABSkill")
 
-		self.url = "http://%s:%s/rest" % (self.config.get('host'), self.config.get('port'))
+		self.url = "http://%s:%s/rest" % (self.settings.get('host'), self.settings.get('port'))
 
 		self.command_headers = {"Content-type": "text/plain"}
 

--- a/settingsmeta.yaml
+++ b/settingsmeta.yaml
@@ -1,0 +1,12 @@
+name: openHAB
+skillMetadata:
+  sections:
+    - name: Connection
+      fields:
+        - name: host
+          label: openHAB server IP
+          type: text
+        - name: port
+          label: openHAB server port
+          type: number
+          value: 8080


### PR DESCRIPTION
In the release notes for Mycroft 19.8:
_MycroftSkill.config no longer exists. Any skill specific settings should be made using the settings.json in the skills folder._
This PR changes the code to using skill settings. This also has the benefit of giving the user a way to configure openHAB server and port in the web gui.