### PR TITLE
Handle unconfigured state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.pyc
+settings.json

--- a/__init__.py
+++ b/__init__.py
@@ -48,7 +48,10 @@ class openHABSkill(MycroftSkill):
 	def __init__(self):
 		super(openHABSkill, self).__init__(name="openHABSkill")
 
-		self.url = "http://%s:%s/rest" % (self.settings.get('host'), self.settings.get('port'))
+		if self.settings.get('host') is not None and self.settings.get('port') is not None:
+		    self.url = "http://%s:%s/rest" % (self.settings.get('host'), self.settings.get('port'))
+		else:
+		    self.url = None
 
 		self.command_headers = {"Content-type": "text/plain"}
 
@@ -62,8 +65,6 @@ class openHABSkill(MycroftSkill):
 		self.targetTemperatureItemsDic = dict()
 		#self.homekitHeatingCoolingModeDic = dict()
 
-		self.getTaggedItems()
-
 	def initialize(self):
 	
 		supported_languages = ["en-US", "it-IT", "de-DE", "es-ES"]
@@ -71,6 +72,11 @@ class openHABSkill(MycroftSkill):
 		if self.lang not in supported_languages:
 			self.log.warning("Unsupported language for " + self.name + ", shutting down skill.")
 			self.shutdown()
+
+		if self.url is not None:
+		    self.getTaggedItems()
+		else:
+		    self.speak_dialog('GetItemsListError')
 
 		refresh_tagged_items_intent = IntentBuilder("RefreshTaggedItemsIntent").require("RefreshTaggedItemsKeyword").build()
 		self.register_intent(refresh_tagged_items_intent, self.handle_refresh_tagged_items_intent)
@@ -131,6 +137,9 @@ class openHABSkill(MycroftSkill):
 
 		except KeyError:
 					pass
+		except Exception:
+				LOGGER.error("Some issues with the command execution!")
+				self.speak_dialog('GetItemsListError')
 
 	def findItemName(self, itemDictionary, messageItem):
 

--- a/__init__.py
+++ b/__init__.py
@@ -96,6 +96,8 @@ class openHABSkill(MycroftSkill):
 		list_items_intent = IntentBuilder("ListItemsIntent").require("ListItemsKeyword").build()
 		self.register_intent(list_items_intent, self.handle_list_items_intent)
 
+		self.settings_change_callback = self.handle_websettings_update
+
 	def getTaggedItems(self):
 		#find all the items tagged Lighting and Switchable from openHAB
 		#the labeled items are stored in dictionaries
@@ -363,6 +365,11 @@ class openHABSkill(MycroftSkill):
 		else:
 			LOGGER.error("Item not found!")
 			self.speak_dialog('ItemNotFoundError')
+
+	def handle_websettings_update(self):
+		if self.settings.get('host') is not None and self.settings.get('port') is not None:
+		    self.url = "http://%s:%s/rest" % (self.settings.get('host'), self.settings.get('port'))
+		    self.getTaggedItems()
 
 	def sendStatusToItem(self, ohItem, command):
 		requestUrl = self.url+"/items/%s/state" % (ohItem)

--- a/settingsmeta.yaml
+++ b/settingsmeta.yaml
@@ -1,4 +1,3 @@
-name: openHAB
 skillMetadata:
   sections:
     - name: Connection
@@ -6,6 +5,7 @@ skillMetadata:
         - name: host
           label: openHAB server IP
           type: text
+          value: 127.0.0.1
         - name: port
           label: openHAB server port
           type: number


### PR DESCRIPTION
Set default value for host in settingsmeta and remove deprecated option
Check for None in config values
Move getTaggedItems to initialize so that speak_dialog works and handle
request error
Handle update of settings

Signed-off-by: Håvard Moen <post@haavard.name>