### PR TITLE
Improve initial settings fetch

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -49,15 +49,11 @@ class openHABSkill(MycroftSkill):
 	def __init__(self):
 		super(openHABSkill, self).__init__(name="openHABSkill")
 
-		if self.get_config('host') is not None and self.get_config('port') is not None:
-		    self.url = "http://%s:%s/rest" % (self.get_config('host'), self.get_config('port'))
-		else:
-		    self.url = None
-
 		self.command_headers = {"Content-type": "text/plain"}
 
 		self.polling_headers = {"Accept": "application/json"}
 
+		self.url = None
 		self.lightingItemsDic = dict()
 		self.switchableItemsDic = dict()
 		self.currentTempItemsDic = dict()
@@ -65,22 +61,20 @@ class openHABSkill(MycroftSkill):
 		#self.currentThermostatItemsDic = dict()
 		self.targetTemperatureItemsDic = dict()
 		#self.homekitHeatingCoolingModeDic = dict()
-	
-	def get_config(self, key):
-		return (self.settings.get(key) or self.config_core.get('openHABSkill', {}).get(key))
-	
+
 	def initialize(self):
-	
+
 		supported_languages = ["en-us", "it-it", "de-de", "es-es"]
-		
+
 		if self.lang not in supported_languages:
 			self.log.warning("Unsupported language for " + self.name + ", shutting down skill.")
 			self.shutdown()
 
+		self.handle_websettings_update()
 		if self.url is not None:
 		    self.getTaggedItems()
 		else:
-		    self.speak_dialog('GetItemsListError')
+		    self.speak_dialog('ConfigurationNeeded')
 
 		refresh_tagged_items_intent = IntentBuilder("RefreshTaggedItemsIntent").require("RefreshTaggedItemsKeyword").build()
 		self.register_intent(refresh_tagged_items_intent, self.handle_refresh_tagged_items_intent)
@@ -101,6 +95,16 @@ class openHABSkill(MycroftSkill):
 		self.register_intent(list_items_intent, self.handle_list_items_intent)
 
 		self.settings_change_callback = self.handle_websettings_update
+
+	def get_config(self, key):
+		return (self.settings.get(key) or self.config_core.get('openHABSkill', {}).get(key))
+
+	def handle_websettings_update(self):
+		if self.get_config('host') is not None and self.get_config('port') is not None:
+			self.url = "http://%s:%s/rest" % (self.get_config('host'), self.get_config('port'))
+			self.getTaggedItems()
+		else:
+		    self.url = None
 
 	def getTaggedItems(self):
 		#find all the items tagged Lighting and Switchable from openHAB
@@ -276,18 +280,18 @@ class openHABSkill(MycroftSkill):
 	def	handle_what_status_intent(self, message):
 		messageItem = message.data.get('Item')
 		requestType = message.data.get('RequestType')
-		
+
 		unitOfMeasure = "degree"
 		infoType = "temperature"
-		
+
 		if (self.lang == "it-it"):
 			unitOfMeasure = "gradi"
 			infoType = "temperatura"
-		
+
 		if (self.lang == "de-de"):
 			unitOfMeasure = "Grad"
 			infoType = "Temperatur"
-			
+
 		if (self.lang == "es-es"):
 			unitOfMeasure = "grados"
 			infoType = "temperatura"
@@ -313,9 +317,9 @@ class openHABSkill(MycroftSkill):
 			infoType = "status"
 			unitOfMeasure = ""
 			if (self.lang == "it-it"):
-				unitOfMeasure = "stato"				
+				unitOfMeasure = "stato"
 			if (self.lang == "de-de"):
-				unitOfMeasure = "Status"				
+				unitOfMeasure = "Status"
 			if (self.lang == "es-es"):
 				unitOfMeasure = "estado"
 			self.currStatusItemsDic.update(self.switchableItemsDic)
@@ -369,11 +373,6 @@ class openHABSkill(MycroftSkill):
 		else:
 			LOGGER.error("Item not found!")
 			self.speak_dialog('ItemNotFoundError')
-
-	def handle_websettings_update(self):
-		if self.get_config('host') is not None and self.get_config('port') is not None:
-		    self.url = "http://%s:%s/rest" % (self.get_config('host'), self.get_config('port'))
-		    self.getTaggedItems()
 
 	def sendStatusToItem(self, ohItem, command):
 		requestUrl = self.url+"/items/%s/state" % (ohItem)

--- a/dialog/en-us/ConfigurationNeeded.dialog
+++ b/dialog/en-us/ConfigurationNeeded.dialog
@@ -1,0 +1,1 @@
+Please add your open hab server details in the Skill settings at home dot mycroft dot AI


### PR DESCRIPTION
Hi there, was just giving the Skill a test run as part of the review process and thought we could improve the initial load of settings.

This moves the load of settings to after the Skill has been constructed as web settings will never be available during `__init__`.

Added a new dialog for configuration needed. Previously it reported that it could not load the list which might be interpreted as - the Skill has connected but something went wrong.