### PR TITLE
example of using Mycroft translate methods

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -65,14 +65,14 @@ class openHABSkill(MycroftSkill):
 		#self.currentThermostatItemsDic = dict()
 		self.targetTemperatureItemsDic = dict()
 		#self.homekitHeatingCoolingModeDic = dict()
-	
+
 	def get_config(self, key):
 		return (self.settings.get(key) or self.config_core.get('openHABSkill', {}).get(key))
-	
+
 	def initialize(self):
-	
+
 		supported_languages = ["en-us", "it-it", "de-de", "es-es"]
-		
+
 		if self.lang not in supported_languages:
 			self.log.warning("Unsupported language for " + self.name + ", shutting down skill.")
 			self.shutdown()
@@ -276,46 +276,22 @@ class openHABSkill(MycroftSkill):
 	def	handle_what_status_intent(self, message):
 		messageItem = message.data.get('Item')
 		requestType = message.data.get('RequestType')
-		
-		unitOfMeasure = "degree"
-		infoType = "temperature"
-		
-		if (self.lang == "it-it"):
-			unitOfMeasure = "gradi"
-			infoType = "temperatura"
-		
-		if (self.lang == "de-de"):
-			unitOfMeasure = "Grad"
-			infoType = "Temperatur"
-			
-		if (self.lang == "es-es"):
-			unitOfMeasure = "grados"
-			infoType = "temperatura"
+
+		unitOfMeasure = self.translate_namedvalues('unitsOfMeasure')[requestType]
 
 		self.currStatusItemsDic = dict()
 
-		if((requestType == "temperature") or (requestType == "la temperatura") or (requestType == "temperatur") or (requestType == "temperatura")):
+		if requestType == self.translate("temperature"):
 			self.currStatusItemsDic.update(self.currentTempItemsDic)
 		elif((requestType == "humidity")  or (requestType == "l'umidità") or (requestType == "Feuchtigkeit") or (requestType == "humedad")):
-			unitOfMeasure = "percentage"
-			infoType = "humidity"
-			if (self.lang == "it-it"):
-				unitOfMeasure = "percento"
-				infoType = "umidità"
-			if (self.lang == "de-de"):
-				unitOfMeasure = "Prozentsatz"
-				infoType = "Feuchtigkeit"
-			if (self.lang == "es-es"):
-				unitOfMeasure = "porciento"
-				infoType = "humedad"
 			self.currStatusItemsDic.update(self.currentHumItemsDic)
 		elif((requestType == "status") or (requestType == "lo stato") or (requestType == "Status") or (requestType == "estado")):
 			infoType = "status"
 			unitOfMeasure = ""
 			if (self.lang == "it-it"):
-				unitOfMeasure = "stato"				
+				unitOfMeasure = "stato"
 			if (self.lang == "de-de"):
-				unitOfMeasure = "Status"				
+				unitOfMeasure = "Status"
 			if (self.lang == "es-es"):
 				unitOfMeasure = "estado"
 			self.currStatusItemsDic.update(self.switchableItemsDic)

--- a/vocab/de-de/temperature.voc
+++ b/vocab/de-de/temperature.voc
@@ -1,0 +1,1 @@
+temperatur

--- a/vocab/de-de/unitsOfMeasure.value
+++ b/vocab/de-de/unitsOfMeasure.value
@@ -1,0 +1,2 @@
+temperatur,grad
+feuchtigkeit,prozentsatz

--- a/vocab/en-us/temperature.voc
+++ b/vocab/en-us/temperature.voc
@@ -1,0 +1,1 @@
+temperature

--- a/vocab/en-us/unitsOfMeasure.value
+++ b/vocab/en-us/unitsOfMeasure.value
@@ -1,0 +1,2 @@
+temperature,degree
+humidity,percentage

--- a/vocab/es-es/temperature.voc
+++ b/vocab/es-es/temperature.voc
@@ -1,0 +1,1 @@
+temperatura

--- a/vocab/es-es/unitsOfMeasure.value
+++ b/vocab/es-es/unitsOfMeasure.value
@@ -1,0 +1,2 @@
+temperatura,grados
+humedad,porciento

--- a/vocab/it-it/temperature.voc
+++ b/vocab/it-it/temperature.voc
@@ -1,0 +1,1 @@
+temperatura

--- a/vocab/it-it/unitsOfMeasure.value
+++ b/vocab/it-it/unitsOfMeasure.value
@@ -1,0 +1,2 @@
+temperatura,gradi
+umidità,percento


### PR DESCRIPTION
Hi Tommy, 

This is not required for inclusion in the Marketplace, and isn't even complete. I just wanted to give an example of some of the translation methods we have available that might simplify the code a little, particularly as even more languages get added. Mycroft Skills are now being translated to over 50 languages!

You can see documentation on these methods at:
- [`translate`](https://mycroft-core.readthedocs.io/en/latest/source/mycroft.html?highlight=named#mycroft.MycroftSkill.translate) 
- [`translate_namedvalues`](https://mycroft-core.readthedocs.io/en/latest/source/mycroft.html?highlight=named#mycroft.MycroftSkill.translate_namedvalues) 
- [`voc_match` method](https://mycroft-core.readthedocs.io/en/latest/source/mycroft.html#mycroft.MycroftSkill.voc_match)