### PR TITLE
Add simple integration test

### DIFF
--- a/test/intent/RefreshItems.intent.json
+++ b/test/intent/RefreshItems.intent.json
@@ -1,0 +1,5 @@
+{
+  "utterance": "refresh openhab items",
+  "intent_type": "RefreshTaggedItemsIntent",
+  "expected_dialog": "GetItemsListError"
+}


### PR DESCRIPTION
Given our testrunner will not have an openHAB system to connect to this is probably the limit of testing we can achieve without some extensive mocking. However it at least confirms the Skill installed and ran correctly.

You can test this by running:
```
mycroft-skill-testrunner /opt/mycroft/skills/openhab-mycroft.openhab
```

Signed-off-by: Kris Gesling <kris.gesling@mycroft.ai> (github: krisgesling)