### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -18,7 +18,7 @@ from os.path import dirname
 from adapt.intent import IntentBuilder
 from mycroft.skills.core import MycroftSkill, intent_handler
 from mycroft.util.log import getLogger
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 
 import requests
 import json
@@ -167,7 +167,7 @@ class openHABSkill(MycroftSkill):
 
 		try:
 			for itemName, itemLabel in list(itemDictionary.items()):
-				score = fuzz.ratio(messageItem, itemLabel)
+				score = fuzz.ratio(messageItem, itemLabel, score_cutoff=bestScore)
 				if score > bestScore:
 					bestScore = score
 					bestItem = itemName

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 requests>=2.10.0
-fuzzywuzzy==0.14.0
-python-Levenshtein==0.12.0
+rapidfuzz==0.7.6


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/maxbachmann/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy