### PR TITLE
Semantic model tag support

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -101,33 +101,33 @@ Switch Kitchen_Light_A2 "Kitchen LEDs"                    ["Lighting"] {channel=
 
 Each item tag supports different command, here is the summary:
 
-| Tag                    | Key word    | Commands            |
-|------------------------|-------------|---------------------|
-| `Switchable`           | turn        | on, off             |
-|                        | switch      | on, off             |
-|                        | put         | on, off             |
-|                        | what's      | status              |
-|                        |             |                     |
-| `Lighting`             | turn        | on, off             |
-|                        | switch      | on, off             |
-|                        | put         | on, off             |
-|                        | dim         |                     |
-|                        | dim by      | value in percentage |
-|                        | bright      |                     |
-|                        | bright by   | value in percentage |
-|                        |             |                     |
-| `Thermostat`           | adjust to   | values in degrees   |
-|                        | regulate to | values in degrees   |
-|                        | tune to     | values in degrees   |
-|                        | decrease by | values in degrees   |
-|                        | increase by | values in degrees   |
-|                        | what's      | adjusted to         |
-|                        | what's      | regulated to        |
-|                        | what's      | tuned to            |
-|                        |             |                     |
-| `CurrentHumidity`      | what's      | humidity            |
-|                        |             |                     |
-| `CurrentTemperature`   | what's      | temperature         |
+| Tag(s)                                                                                                 | Key word    | Commands            |
+|--------------------------------------------------------------------------------------------------------|-------------|---------------------|
+| `["Switchable"]` or `["Switch", "Power"]`                                                              | turn        | on, off             |
+|                                                                                                        | switch      | on, off             |
+|                                                                                                        | put         | on, off             |
+|                                                                                                        | what's      | status              |
+|                                                                                                        |             |                     |
+| `["Lighting"]` or `["Switch", "Light"]` or `["Control", "Light"]` or `["Control", "ColorTemperature"]` | turn        | on, off             |
+|                                                                                                        | switch      | on, off             |
+|                                                                                                        | put         | on, off             |
+|                                                                                                        | dim         |                     |
+|                                                                                                        | dim by      | value in percentage |
+|                                                                                                        | bright      |                     |
+|                                                                                                        | bright by   | value in percentage |
+|                                                                                                        |             |                     |
+| `["Thermostat"]` or `["Temperature", "Setpoint"]`                                                      | adjust to   | values in degrees   |
+|                                                                                                        | regulate to | values in degrees   |
+|                                                                                                        | tune to     | values in degrees   |
+|                                                                                                        | decrease by | values in degrees   |
+|                                                                                                        | increase by | values in degrees   |
+|                                                                                                        | what's      | adjusted to         |
+|                                                                                                        | what's      | regulated to        |
+|                                                                                                        | what's      | tuned to            |
+|                                                                                                        |             |                     |
+| `["CurrentHumidity"]` or `["Measurement", "Humidity"]`                                                 | what's      | humidity            |
+|                                                                                                        |             |                     |
+| `["CurrentTemperature"]` or `["Measurement", "Temperature"]`                                           | what's      | temperature         |
 
 With references to the above item definitions, here are an examples of working commands:
 

--- a/__init__.py
+++ b/__init__.py
@@ -133,22 +133,49 @@ class openHABSkill(MycroftSkill):
 				if req.status_code == 200:
 					json_response = req.json()
 					for x in range(0,len(json_response)):
-						if ("Lighting" in json_response[x]['tags']):
-							self.lightingItemsDic.update({json_response[x]['name']: json_response[x]['label']})
-						elif ("Switchable" in json_response[x]['tags']):
-							self.switchableItemsDic.update({json_response[x]['name']: json_response[x]['label']})
-						elif ("CurrentTemperature" in json_response[x]['tags']):
-							self.currentTempItemsDic.update({json_response[x]['name']: json_response[x]['label']})
-						elif ("CurrentHumidity" in json_response[x]['tags']):
-							self.currentHumItemsDic.update({json_response[x]['name']: json_response[x]['label']})
-						elif ("Thermostat" in json_response[x]['tags']):
-							self.currentThermostatItemsDic.update({json_response[x]['name']: json_response[x]['label']})
-						elif ("TargetTemperature" in json_response[x]['tags']):
-							self.targetTemperatureItemsDic.update({json_response[x]['name']: json_response[x]['label']})
-						elif ("homekit:HeatingCoolingMode" in json_response[x]['tags']):
-							self.homekitHeatingCoolingModeDic.update({json_response[x]['name']: json_response[x]['label']})
+
+						# Semantic model tags
+						if "Control" in json_response[x]['tags']:
+							if "ColorTemperature" in json_response[x]['tags']:
+								self.lightingItemsDic.update({json_response[x]['name']: json_response[x]['label']})
+							elif "Light" in json_response[x]['tags']:
+								self.lightingItemsDic.update({json_response[x]['name']: json_response[x]['label']})
+						elif "Measurement" in json_response[x]['tags']:
+							if "Humidity" in json_response[x]['tags']:
+								self.currentHumItemsDic.update(
+									{json_response[x]['name']: json_response[x]['label']})
+							elif "Temperature" in json_response[x]['tags']:
+								self.currentTempItemsDic.update(
+									{json_response[x]['name']: json_response[x]['label']})
+						elif "Setpoint" in json_response[x]['tags']:
+							if "Temperature" in json_response[x]['tags']:
+								self.targetTemperatureItemsDic.update(
+									{json_response[x]['name']: json_response[x]['label']})
+						elif "Switch" in json_response[x]['tags']:
+							if "Light" in json_response[x]['tags']:
+								self.lightingItemsDic.update({json_response[x]['name']: json_response[x]['label']})
+							elif "Power" in json_response[x]['tags']:
+								self.switchableItemsDic.update(
+									{json_response[x]['name']: json_response[x]['label']})
 						else:
-							pass
+							# Old tags
+							if ("Lighting" in json_response[x]['tags']):
+								self.lightingItemsDic.update({json_response[x]['name']: json_response[x]['label']})
+							elif ("Switchable" in json_response[x]['tags']):
+								self.switchableItemsDic.update({json_response[x]['name']: json_response[x]['label']})
+							elif ("CurrentTemperature" in json_response[x]['tags']):
+								self.currentTempItemsDic.update({json_response[x]['name']: json_response[x]['label']})
+							elif ("CurrentHumidity" in json_response[x]['tags']):
+								self.currentHumItemsDic.update({json_response[x]['name']: json_response[x]['label']})
+							elif ("Thermostat" in json_response[x]['tags']):
+								self.currentThermostatItemsDic.update(
+									{json_response[x]['name']: json_response[x]['label']})
+							elif ("TargetTemperature" in json_response[x]['tags']):
+								self.targetTemperatureItemsDic.update(
+									{json_response[x]['name']: json_response[x]['label']})
+							elif ("homekit:HeatingCoolingMode" in json_response[x]['tags']):
+								self.homekitHeatingCoolingModeDic.update(
+									{json_response[x]['name']: json_response[x]['label']})
 				else:
 					LOGGER.error("Some issues with the command execution!")
 					self.speak_dialog('GetItemsListError')


### PR DESCRIPTION
Added support for the following semantic tags: `["Switch", "Power"]` `["Switch", "Light"]` `["Control", "Light"]` `["Control", "ColorTemperature"]` `["Temperature", "Setpoint"]` `["Measurement", "Humidity"]` `["Measurement", "Temperature"]`.